### PR TITLE
remove nsmd running detection

### DIFF
--- a/libseq66/src/sessions/clinsmanager.cpp
+++ b/libseq66/src/sessions/clinsmanager.cpp
@@ -113,16 +113,6 @@ clinsmanager::detect_session (std::string & url)
         url = tenturl;
     }
 #endif
-    if (result)
-    {
-        bool testing = url == "testing";
-        if (! testing)                              /* for troubleshooting  */
-        {
-            result = pid_exists("nsmd");            /* one final check      */
-            if (! result)
-                warnprint("nsmd not running, proceeding with normal run");
-        }
-    }
     return result;
 }
 


### PR DESCRIPTION
nsmd running detection is not required and prevent to work with RaySession or any other NSM session manager (Carla for example). RaySession doesn't uses nsmd but its own daemon ray-daemon. However, it's a very bad idea to check that nsmd or ray-daemon is running, it will prevent it to work with a possible futur session manager.

I note another big problem with NSM protocol, qseq66 never replies to the /nsm/client/open message, that is why the client status is still on 'open'. It should invokes nsmbase::open_reply  once the qseq66 project is ready. (I wonder why there are nsmbase.cpp and nsmclient.cpp).

