### PR TITLE
Fix fedora 34 build

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -110,6 +110,16 @@ OpenSUSE Tumbleweed:
     One might need to run the "reconf" script located in contrib/scripts/reconf.
     Otherwise ./configure drops an error.  Lastly, run ./configure and make.
 
+Fedora:
+    $ mkdir -p ~/.local/bin/qt
+    $ ln -s /bin/qmake-qt5 ~/.local/bin/qmake
+    $ ln -s /bin/rcc-qt5 ~/.local/bin/rcc
+    $ ln -s /bin/uic-qt5 ~/.local/bin/uic
+    $ ln -s /bin/lrelease-qt5 ~/.local/bin/lrelease
+    $ ln -s /bin/lupdate-qt5 ~/.local/bin/lupdate
+    $ ln -s /bin/moc-qt5 ~/.local/bin/moc
+    $ export PATH=$PATH:~/.local/bin/qt
+
 Advanced Steps:
 
     These steps are meant for those who want to try the various versions of

--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,11 @@ AC_DEFINE(APP_TYPE, ["qt5"], "The type of the Seq66 executable, qt/cli")
 AC_DEFINE(APP_ENGINE, ["rtmidi"], "Seq66 MIDI engine, rtmidi/portmidi")
 build_os="'$(uname -srm)'"
 AC_DEFINE_UNQUOTED(APP_BUILD_OS, ["$build_os"], "OS/kernel where build was done")
-build_issue="'$(cat /etc/issue.net)'"
-AC_DEFINE_UNQUOTED(APP_BUILD_ISSUE, ["$build_issue"], "Distro of build")
+AC_DEFINE_UNQUOTED(
+                   APP_BUILD_ISSUE,
+                   dnl Get the value of /etc/issue.net and remove new lines.
+                   "[m4_normalize(esyscmd([cat /etc/issue.net]))]",
+                   "Distro of build")
 AC_DEFINE(CLIENT_NAME, ["seq66"], "The name to display as client/port")
 
 VERSION="0.97.2.1"

--- a/m4/ax_have_qt.m4
+++ b/m4/ax_have_qt.m4
@@ -68,7 +68,7 @@ AC_DEFUN([AX_HAVE_QT],
   AC_MSG_CHECKING(for Qt)
   # If we have Qt5 or later in the path, we're golden
   ver=`qmake --version | grep -o "Qt version ."`
-  if test "$ver" ">" "Qt version 4"; then
+  if test "$ver" "==" "Qt version 5"; then
     have_qt=yes
     # This pro file dumps qmake's variables, but it only works on Qt 5 or later
     am_have_qt_pro=`mktemp`

--- a/m4/ax_have_qt_ex.m4
+++ b/m4/ax_have_qt_ex.m4
@@ -71,7 +71,7 @@ AC_DEFUN([AX_HAVE_QT_EX],
   AC_MSG_CHECKING(for Qt)
   # If we have Qt5 or later in the path, we're golden
   ver=`qmake --version | grep -o "Qt version ."`
-  if test "$ver" ">" "Qt version 4"; then
+  if test "$ver" "==" "Qt version 5"; then
     have_qt=yes
     # This pro file dumps qmake's variables, but it only works on Qt 5 or later
     am_have_qt_pro=`mktemp`

--- a/m4/ax_have_qt_min.m4
+++ b/m4/ax_have_qt_min.m4
@@ -77,7 +77,7 @@ AC_DEFUN([AX_HAVE_QT_MIN],
   AC_MSG_CHECKING(for Qt)
   # If we have Qt5 or later in the path, we're golden
   ver=`qmake --version | grep -o "Qt version ."`
-  if test "$ver" ">" "Qt version 4"; then
+  if test "$ver" "==" "Qt version 5"; then
     have_qt=yes
     # This pro file dumps qmake's variables, but it only works on Qt 5 or later
     am_have_qt_pro=`mktemp`


### PR DESCRIPTION
Solve [this](https://github.com/ahlstromcj/seq66/issues/69).
It remove the problematic new line. It also check that qmake version is equal to 5 instead of bigger than 4, cause build it with qmake-qt6 fail.