### PR TITLE
seq66.desktop: fix typo; add X-NSM-Exec=qseq66

### DIFF
--- a/data/share/applications/seq66.desktop
+++ b/data/share/applications/seq66.desktop
@@ -9,4 +9,5 @@ Type=Application
 Terminal=false
 Icon=qseq66
 Categories=Qt;AudioVideo;Audio;Midi;Music;Sequencer;X-Alsa;X-Jack;X-MIDI;
-X-NSM-capable=true
+X-NSM-Capable=true
+X-NSM-Exec=qseq66

--- a/distros/debian/seq66.desktop
+++ b/distros/debian/seq66.desktop
@@ -10,3 +10,4 @@ Categories=Qt;AudioVideo;Audio;Midi;Music;Sequencer;X-Alsa;X-Jack;X-MIDI;
 Exec=qseq66
 Terminal=false
 X-NSM-Capable=true
+X-NSM-Exec=qseq66


### PR DESCRIPTION
There was a typo: lowercase vs uppercase. 

X-NSM-Exec is the executable name for the NSM client when it is used in NSM. As the package itself is called seq66 and the executable name is qseq66, I think it's good to add it. 